### PR TITLE
Fixed PHP 5.4 compatibility

### DIFF
--- a/src/Baun.php
+++ b/src/Baun.php
@@ -55,7 +55,8 @@ class Baun {
 		$this->contentParser = new $contentParserProvider;
 
 		// Plugins
-		if (!empty($this->config->get('plugins'))) {
+		$plugins = $this->config->get('plugins');
+		if (!empty($plugins)) {
 			foreach ($this->config->get('plugins') as $pluginClass) {
 				if (class_exists($pluginClass)) {
 					new $pluginClass($this->config, $this->events, $this->router, $this->theme, $this->contentParser);


### PR DESCRIPTION
Moved arbitrary expressions out of the empty function for PHP 5.4
compatibility
