### PR TITLE
Adding show_folders_on_nav config

### DIFF
--- a/src/Baun.php
+++ b/src/Baun.php
@@ -316,7 +316,7 @@ class Baun {
 		$blogBase = str_replace($this->config->get('app.content_path'), '', $this->blogPath);
 
 		foreach ($files as $key => $value) {
-			if (!is_int($key)) {
+			if (!is_int($key) && $this->config->get('app.show_folders_on_nav') !== false) {
 				if ($key == $blogBase) {
 					$url = basename($blogBase);
 					if (preg_match('/^\d+\-/', $url)) {
@@ -337,7 +337,7 @@ class Baun {
 						$result[$key] = $this->filesToNav($value, $currentUri, $route_prefix . $key . '/', $path_prefix . $key . '/');
 					}
 				}
-			} elseif ($path_prefix != $blogBase . '/') {
+			} elseif (is_int($key) && $path_prefix != $blogBase . '/') {
 				$route = str_replace($this->config->get('app.content_extension'), '', $value['nice']);
 				if ($route == 'index') {
 					$route = '/';


### PR DESCRIPTION
Up for discussion but was needed for me. I had my navigation set up, Journal for example was a page, but there was going to be journal/xyz pages, but I didn't want to list those journal/xyz pages on my navigation, as the Journal page was going to list all the pages anyway.

This might be possible with exclude_from_nav somehow?
