### PR TITLE
Pass an arbitrary number of arguments to event listener.

### DIFF
--- a/src/Baun.php
+++ b/src/Baun.php
@@ -219,8 +219,9 @@ class Baun {
 						}
 						$data['published'] = $published;
 
-						$this->events->emit('baun.beforePostRender', $template, $data);
-						return $this->theme->render($template, $data);
+						$dataObject = json_decode(json_encode($data));
+						$this->events->emit('baun.beforePostRender', $template, $dataObject);
+						return $this->theme->render($template, (array)$dataObject);
 					});
 				}
 			}

--- a/src/Baun.php
+++ b/src/Baun.php
@@ -176,7 +176,18 @@ class Baun {
 		}
 
 		$navigation = $this->filesToNav($files, $this->router->currentUri());
-		$this->events->emit('baun.filesToNav', $navigation);
+
+		$navigationObject = new \stdClass();
+		$navigationObject->nodes = $navigation;
+
+		// $navigation is passed by value, $navigationObject is passed by reference
+		$this->events->emit('baun.filesToNav', $navigation, $navigationObject);
+
+		// If navigation nodes have been updated by the listener
+		if ($navigation !== $navigationObject->nodes) {
+			$navigation = $navigationObject->nodes;
+		}
+
 		$this->theme->custom('baun_nav', $navigation);
 
 		$routes = $this->filesToRoutes($files);

--- a/src/Interfaces/Events.php
+++ b/src/Interfaces/Events.php
@@ -12,11 +12,10 @@ interface Events {
 	public function addListener($name, $listener, $priority = 0);
 
 	/**
-	 * Emit the given event
+	 * Emit the given event with optional additional parameters
 	 *
 	 * @param string $event event name
-	 * @param array $args optional args to pass to event listener
 	 */
-	public function emit($event, $args = []);
+	public function emit($event);
 
 }

--- a/src/Providers/Events.php
+++ b/src/Providers/Events.php
@@ -17,9 +17,9 @@ class Events implements EventsInterface {
 		$this->emitter->addListener($name, $listener, $priority);
 	}
 
-	public function emit($event, $args = [])
+	public function emit($event)
 	{
-		$this->emitter->emit($event, $args);
+		call_user_func_array(array($this->emitter, 'emit'), func_get_args());
 	}
 
 }


### PR DESCRIPTION
This PR fixes issue #14 

The existing problems, as I understand them, are:
1. The `emit` function as defined in `Baun\Interfaces\Events` expects the second parameter to be an array of arguments, however, when the `emit` function is called from within the Baun application, this is never the case.
2. Sometimes multiple arguments are sent when the `emit` function is called from the Baun application, but due to the `Events` provider only handling one argument, anything after the first argument is simply ignored.
3. The `emit` method in `Baun\Providers\Events` sends the arguments in an array to `League\Event\Emitter`'s `emit` function, which is incorrect; it doesn't expect an array of parameters, it expects any arbitrary number of parameters which it accesses via `user_func_get_args()`

So, I have modified `Baun\Interfaces\Events` to not take an `$args` parameter. Instead, it can take an arbitrary number of additional arguments which it will call `League\Event\Emitter::emit` using `call_user_func_array()` with an array of arguments from `func_get_args()`.

Hopefully this now makes the Baun framework consistent with `Leage\Event` and behave in the way that most people will expect it to. :)
