### PR TITLE
Allow ability to edit navigation nodes in baun.filesToNav event listener

### DIFF
--- a/src/Baun.php
+++ b/src/Baun.php
@@ -219,8 +219,9 @@ class Baun {
 						}
 						$data['published'] = $published;
 
-						$this->events->emit('baun.beforePostRender', $template, $data);
-						return $this->theme->render($template, $data);
+						$dataObject = json_decode(json_encode($data));
+						$this->events->emit('baun.beforePostRender', $template, $dataObject);
+						return $this->theme->render($template, (array)$dataObject);
 					});
 				}
 			}

--- a/src/Baun.php
+++ b/src/Baun.php
@@ -176,7 +176,18 @@ class Baun {
 		}
 
 		$navigation = $this->filesToNav($files, $this->router->currentUri());
-		$this->events->emit('baun.filesToNav', $navigation);
+
+		$navigationObject = new \stdClass();
+		$navigationObject->nodes = $navigation;
+
+		// $navigation is passed by value, $navigationObject is passed by reference
+		$this->events->emit('baun.filesToNav', $navigation, $navigationObject);
+
+		// If navigation nodes have been updated by the listener
+		if ($navigation !== $navigationObject->nodes) {
+			$navigation = $navigationObject->nodes;
+		}
+
 		$this->theme->custom('baun_nav', $navigation);
 
 		$routes = $this->filesToRoutes($files);

--- a/src/Interfaces/Events.php
+++ b/src/Interfaces/Events.php
@@ -12,11 +12,10 @@ interface Events {
 	public function addListener($name, $listener, $priority = 0);
 
 	/**
-	 * Emit the given event
+	 * Emit the given event with optional additional parameters
 	 *
 	 * @param string $event event name
-	 * @param array $args optional args to pass to event listener
 	 */
-	public function emit($event, $args = []);
+	public function emit($event);
 
 }

--- a/src/Providers/Events.php
+++ b/src/Providers/Events.php
@@ -17,9 +17,9 @@ class Events implements EventsInterface {
 		$this->emitter->addListener($name, $listener, $priority);
 	}
 
-	public function emit($event, $args = [])
+	public function emit($event)
 	{
-		$this->emitter->emit($event, $args);
+		call_user_func_array(array($this->emitter, 'emit'), func_get_args());
 	}
 
 }


### PR DESCRIPTION
Following on from issue #14 and PR #15, the `$navigation` argument in `baun.filesToNav` is an array, and as such, was being passed by value which meant that in any listener, it is effectively read-only.

In order to maintain backwards compatibility, I have added an extra argument `$navigationObject` which contains a `nodes` property. Objects are passed by reference, so the `nodes` property can be edited and passed back to the `Baun` application.

_If_ the `nodes` property is edited, the `Baun` application applies the changes to the `$navigation` variable which is then passed to the `theme` provider's `baun_nav` function.
