### PR TITLE
Add config option to prefix blog post routes with the published date

### DIFF
--- a/src/Baun.php
+++ b/src/Baun.php
@@ -414,6 +414,9 @@ class Baun {
 			if (preg_match('/^\d+\-/', $post['raw'])) {
 				list($time, $path) = explode('-', $post['raw'], 2);
 				$published = date($this->config->get('blog.date_format'), strtotime($time));
+				if ($this->config->get('blog.date_in_url')) {
+					$route = $time . '/' . $route;
+				}
 			}
 			if (isset($data['info']['published'])) {
 				$published = date($this->config->get('blog.date_format'), strtotime($data['info']['published']));


### PR DESCRIPTION
Hello! I'm not sure if this project is still being maintained, but i've started using it and i like it. One thing i found slightly concerning though is that, since Baun uses only the 'nice' file path when producing routes for blog posts, it's not possible to have two blog posts with the same title, even if they have different dates. Attempting to create such a 'duplicate' post causes PHRoute to throw a bad route exception.

This constraint doesn't seem like much of an issue for non-blog pages, but i think it could be problematic for blog posts:
1. Most blog engines auto-enumerate posts with duplicate titles and/or put the date in the URL by default, so users may have the expectation that Baun will function similarly
2. It seems very possible for longer-running blogs to accumulate two posts with the same title

A very very simple fix for this (in 99% of cases anyway) is to add an option to prefix the route with the date. That's what this change does — it adds a `date_in_url` option to the `blog` config to toggle this behaviour. Routes will be produced as follows:

```
Raw file path:                 blog/20150805-my-blog-title.md
URL with date_in_url = false:  /blog/my-blog-title
URL with date_in_url = true:   /blog/20150805/my-blog-title
```

Hope this is useful somehow, cheers
