### PR TITLE
Baun::loadConfigs() should only load files ending in .php

### DIFF
--- a/src/Baun.php
+++ b/src/Baun.php
@@ -114,13 +114,13 @@ class Baun {
 
 		$rdi = new \RecursiveDirectoryIterator(BASE_PATH . 'config/');
 		$rii = new \RecursiveIteratorIterator($rdi);
-		$ri = new \RegexIterator($rii, '/(.*)\.php/', \RegexIterator::GET_MATCH);
+		$ri = new \RegexIterator($rii, '/(.*)\.php$/', \RegexIterator::GET_MATCH);
 		$configFiles = array_keys(iterator_to_array($ri));
 
 		foreach ($configFiles as $configFile) {
 			$configKey = str_replace(BASE_PATH . 'config' . DIRECTORY_SEPARATOR, '', $configFile);
 			$configKey = str_replace(DIRECTORY_SEPARATOR, '-', strtolower($configKey));
-			$configKey = str_replace('.php', '', $configKey);
+			$configKey = substr($configKey, 0, -4);
 			$configData[$configKey] = require $configFile;
 		}
 


### PR DESCRIPTION
There is an issue — rising to the level of a security vulnerability IMO — with the way `Baun::loadConfigs()` gets files from the config directory. It looks for `.php` anywhere in the file name instead of only at the end, which means that it will load editor swap files (`app.php.swp` or `app.php~`), back-up files (`app.php.bak`), &c. If this happens with a Vim swap file, for example, Baun will spew your config in plain text across the top of every page it outputs, potentially leaking sensitive information.

I think the *intention* was for the method to only look for `.php` at the end of the file, so i've changed it to work that way. Potentially people might also want to support stuff like `.php5` and `.php.inc`, but those extensions have fallen out of favour so i think it's reasonable to ignore them.